### PR TITLE
Some findings when going over statechart code.

### DIFF
--- a/spec/statechart_spec.js
+++ b/spec/statechart_spec.js
@@ -99,7 +99,7 @@ describe('State#addSubstate', function() {
   });
 });
 
-describe('Z.State#each', function() {
+describe('State#each', function() {
   it("should yield each state in the receiver's hierarchy", function() {
     var a    = new State('a'),
         b    = new State('b'),
@@ -585,7 +585,7 @@ describe('State#state', function() {
     expect(root.substates).toContain(x);
   });
 
-  it('should pass the options to the `Z.State` constructor', function() {
+  it('should pass the options to the `State` constructor', function() {
     var x = root.state('x', {concurrent: true});
     expect(x.concurrent).toBe(true);
   });

--- a/spec/statechart_spec.js
+++ b/spec/statechart_spec.js
@@ -56,12 +56,6 @@ describe('State constructor function', function() {
     }).toThrow('State: history states are not allowed on concurrent states');
   });
 
-  it('should guard against not using the `new` operator', function() {
-    expect(function() {
-      State('a');
-    }).not.toThrow();
-  });
-
   it('should invoke the given function in the context of the new state when given as the second argument', function() {
     var context = null, f = function() { context = this; }, s;
     s = new State('x', f);
@@ -815,6 +809,38 @@ describe('State#resolve', function() {
     expect(root.resolve(null)).toBeNull();
     expect(root.resolve(undefined)).toBeNull();
   });
+});
+
+describe('Subclass of State', function() {
+  var CustomState = (function(Class){
+    var Subclass, constructor, prop;
+
+    Subclass = function(){ Class.apply(this, arguments); }
+    Subclass.prototype = Object.create(Class.prototype); // inherit
+    Subclass.prototype.constructor = Subclass;
+    for (var prop in Class) {
+      if (Class.hasOwnProperty(prop)) {
+        Subclass[prop] = Class[prop];
+      }
+    }
+    return Subclass;
+  }(State));
+
+  describe('CustomState.define', function() {
+    it('creates instances of CustomState', function() {
+      var state = CustomState.define();
+      expect(state instanceof CustomState).toBe(true);
+    });
+  });
+
+  describe('CustomState#state', function() {
+    it('creates instances of CustomState', function() {
+      var root = CustomState.define(),
+          x = root.state('x');
+      expect(x instanceof CustomState).toBe(true);
+    });
+  });
+
 });
 
 }());

--- a/spec/statechart_spec.js
+++ b/spec/statechart_spec.js
@@ -87,17 +87,6 @@ describe('State#addSubstate', function() {
     expect(a.substates).toContain(c);
   });
 
-  it('should add the given state tot he subtateMap object', function() {
-    var a = new State('a'),
-        b = new State('b'),
-        c = new State('c');
-
-    a.addSubstate(b);
-    expect(a.substateMap).toEqual({b: b});
-    a.addSubstate(c);
-    expect(a.substateMap).toEqual({b: b, c: c});
-  });
-
   it('should set the superstate property of the given state', function() {
     var a = new State('a'),
         b = new State('b'),
@@ -594,7 +583,6 @@ describe('State#state', function() {
     var x = root.state('x');
     expect(x instanceof State).toBe(true);
     expect(root.substates).toContain(x);
-    expect(root.substateMap['x']).toBe(x);
   });
 
   it('should pass the options to the `Z.State` constructor', function() {
@@ -614,7 +602,6 @@ describe('State#state', function() {
       root.state(s);
 
       expect(root.substates).toContain(s);
-      expect(root.substateMap['s']).toBe(s);
       expect(s.superstate).toBe(root);
     });
   });

--- a/spec/statechart_spec.js
+++ b/spec/statechart_spec.js
@@ -448,6 +448,40 @@ describe('State#goto', function() {
   });
 });
 
+describe('canExit', function() {
+  var root, a, b;
+
+  beforeEach(function() {
+    root = new State('root');
+    a = new State('a');
+    b = new State('b');
+
+    root.addSubstate(a);
+    root.addSubstate(b);
+    root.goto();
+  });
+
+  it('blocks transition if it returns false', function(){
+    a.canExit(function(){
+      return false;
+    });
+
+    root.goto('/b');
+    expect(root.current()).toEqual(['/a']);
+  });
+
+  it('gets called with the destination states and context', function(){
+    var canExitArgs;
+    a.canExit(function(){
+      canExitArgs = arguments;
+    });
+
+    root.goto('/b', { context: 'the context' });
+    expect(canExitArgs[0]).toEqual([root.resolve('/b')]);
+    expect(canExitArgs[1]).toEqual('the context');
+  });
+});
+
 describe('condition states', function() {
   var root, a, b, c, d;
 

--- a/spec/statechart_spec.js
+++ b/spec/statechart_spec.js
@@ -470,6 +470,14 @@ describe('canExit', function() {
     expect(root.current()).toEqual(['/a']);
   });
 
+  it('causes goto to return false', function(){
+    a.canExit(function(){
+      return false;
+    });
+
+    expect(root.goto('/b')).toBe(false);
+  });
+
   it('gets called with the destination states and context', function(){
     var canExitArgs;
     a.canExit(function(){

--- a/statechart.js
+++ b/statechart.js
@@ -751,21 +751,14 @@
     //
     // path      - A string containing the path to resolve or an array of path
     //             segments.
-    // origPath  - A string containing the original path that we're attempting to
-    //             resolve. Multiple recursive calls are made to this method so we
-    //             need to pass along the original string path for error messages
-    //             in the case where the path cannot be resolved.
-    // origState - The state where path resolution was originally attempted from.
     //
     // Returns the `State` object the path represents if it can be resolve and
     //   `null` otherwise.
-    resolve: function(path, origPath, origState) {
+    resolve: function(path) {
       var head, next;
 
       if (!path) { return null; }
 
-      origPath  = origPath || path;
-      origState = origState || this;
       path      = typeof path === 'string' ? path.split('/') : path;
       head      = path.shift();
 
@@ -785,7 +778,7 @@
 
       if (!next) { return null; }
 
-      return path.length === 0 ? next : next.resolve(path, origPath, origState);
+      return path.length === 0 ? next : next.resolve(path);
     },
 
     // Public: Returns a formatted string with the state's full path.

--- a/statechart.js
+++ b/statechart.js
@@ -355,14 +355,10 @@
   // Returns nothing.
   // Throws `Error` if both the `concurrent` and `H` options are set.
   function State(name, opts, f) {
-    if (arguments.length === 2) {
-      if (typeof opts === 'function') {
-        f    = opts;
-        opts = {};
-      }
+    if (typeof opts === 'function') {
+      f    = opts;
+      opts = {};
     }
-
-    if (!(this instanceof State)) { return new State(name, opts, f); }
 
     opts = opts || {};
 
@@ -405,7 +401,7 @@
   //
   // Returns the newly created root state.
   State.define = function() {
-    var opts = {}, f = null, s;
+    var constructor = this, opts = {}, f = null, s;
 
     if (arguments.length === 2) {
       opts = arguments[0];
@@ -420,7 +416,7 @@
       }
     }
 
-    s = new State('__root__', opts, f);
+    s = new constructor('__root__', opts, f);
     return s;
   };
 
@@ -454,10 +450,14 @@
   //
   // Returns the newly created state.
   State.prototype.state = function(name, options, f) {
-      var s = name instanceof State ? name :
-        State.apply(null, slice.call(arguments));
-      this.addSubstate(s);
-      return s;
+    var constructor = this.constructor, s;
+    if (name instanceof constructor) {
+      s = name;
+    } else {
+      s = new constructor(name, options, f);
+    }
+    this.addSubstate(s);
+    return s;
   };
 
   // Public: Registers an enter handler to be called with the receiver state

--- a/statechart.js
+++ b/statechart.js
@@ -95,7 +95,7 @@
   //
   // Returns nothing.
   function queueTransition(pivot, states, opts) {
-    (this.__transitions__ = this.__transitions__ || []).push(
+    this.__transitions__.push(
       {pivot: pivot, states: states, opts: opts});
   }
 
@@ -370,18 +370,19 @@
       throw new Error('State: history states are not allowed on concurrent states');
     }
 
-    this.name          = name;
-    this.substates     = [];
-    this.superstate    = null;
-    this.enters        = [];
-    this.exits         = [];
-    this.events        = {};
-    this.concurrent    = !!opts.concurrent;
-    this.history       = !!(opts.H);
-    this.deep          = opts.H === '*';
-    this.__isCurrent__ = false;
-    this.__cache__     = {};
-    this.trace         = false;
+    this.name            = name;
+    this.substates       = [];
+    this.superstate      = null;
+    this.enters          = [];
+    this.exits           = [];
+    this.events          = {};
+    this.concurrent      = !!opts.concurrent;
+    this.history         = !!(opts.H);
+    this.deep            = opts.H === '*';
+    this.__isCurrent__   = false;
+    this.__cache__       = {};
+    this.__transitions__ = [];
+    this.trace           = false;
 
     if (f) { f.call(this); }
   }

--- a/statechart.js
+++ b/statechart.js
@@ -449,7 +449,7 @@
   //   });
   //
   // Returns the newly created state.
-  State.prototype.state = function(name, options, f) {
+  State.prototype.state = function pState_state(name, options, f) {
     var constructor = this.constructor, s;
     if (name instanceof constructor) {
       s = name;
@@ -470,7 +470,7 @@
   // f - A function to call when the state is entered.
   //
   // Returns the receiver.
-  State.prototype.enter = function(f) { this.enters.push(f); return this; };
+  State.prototype.enter = function pState_enter(f) { this.enters.push(f); return this; };
 
   // Public: Registers an exit handler to be called with the receiver state
   // is exited. The `context` option passed to `goto` will be passed to the
@@ -482,7 +482,7 @@
   // f - A function to call when the state is exited.
   //
   // Returns the receiver.
-  State.prototype.exit = function(f) { this.exits.push(f); return this; };
+  State.prototype.exit = function pState_exit(f) { this.exits.push(f); return this; };
 
   // Public: Registers an event handler to be called when an event with a
   // matching name is sent to the state via the `send` method.
@@ -493,7 +493,7 @@
   // f    - A function to call when the event occurs.
   //
   // Returns the receiver.
-  State.prototype.event = function(name, f) { this.events[name] = f; return this; };
+  State.prototype.event = function pState_event(name, f) { this.events[name] = f; return this; };
 
   // Public: Defines a condition state on the receiver state. Condition states
   // are consulted when entering a clustered state without specified destination
@@ -518,7 +518,7 @@
   //   });
   //
   // Returns nothing.
-  State.prototype.C = function(f) {
+  State.prototype.C = function pState_C(f) {
     if (this.concurrent) {
       throw new Error('State#C: a concurrent state may not have a condition state: ' + this);
     }
@@ -527,7 +527,7 @@
   };
 
   // Public: Returns an array of paths to all current leaf states.
-  State.prototype.current = function() {
+  State.prototype.current = function pState_current() {
     var states = _current.call(this), paths = [], i, n;
 
     for (i = 0, n = states.length; i < n; i++) {
@@ -544,7 +544,7 @@
   // f - A function object, it will be invoked once for each state.
   //
   // Returns the receiver.
-  State.prototype.each = function(f) {
+  State.prototype.each = function pState_each(f) {
     var i, n;
 
     f(this);
@@ -559,7 +559,7 @@
   // Public: Adds the given state as a substate of the receiver state.
   //
   // Returns the receiver.
-  State.prototype.addSubstate = function(state) {
+  State.prototype.addSubstate = function pState_addSubstate(state) {
     var deep = this.deep;
     this.substates.push(state);
     state.each(function(s) {
@@ -571,7 +571,7 @@
   };
 
   // Public: Returns the root state.
-  State.prototype.root = function() {
+  State.prototype.root = function pState_root() {
     return this.__cache__.root = this.__cache__.root ||
       (this.superstate ? this.superstate.root() : this);
   };
@@ -594,7 +594,7 @@
   //   a.path(); // => "/a"
   //   b.path(); // => "/a/b"
   //   c.path(); // => "/a/b/c"
-  State.prototype.path = function() {
+  State.prototype.path = function pState_path() {
     var states = _path.call(this), names = [], i, len;
 
     for (i = 1, len = states.length; i < len; i++) {
@@ -642,7 +642,7 @@
   // Throws an `Error` if multiple pivot states are found between the receiver
   //   and destination states.
   // Throws an `Error` if a destination path is not reachable from the receiver.
-  State.prototype.goto = function() {
+  State.prototype.goto = function pState_goto() {
     var root   = this.root(),
         paths  = flatten(slice.call(arguments)),
         opts   = typeof paths[paths.length - 1] === 'object' ? paths.pop() : {},
@@ -700,7 +700,7 @@
   //
   // Returns a boolean indicating whether or not the event was handled.
   // Throws `Error` if the state is not current.
-  State.prototype.send = function() {
+  State.prototype.send = function pState_send() {
     var args = slice.call(arguments), events = this.events, handled;
 
     if (!this.__isCurrent__) {
@@ -726,14 +726,14 @@
   };
 
   // Public: Resets the statechart by exiting all current states.
-  State.prototype.reset = function() { exit.call(this, {}); };
+  State.prototype.reset = function pState_reset() { exit.call(this, {}); };
 
   // Public: Returns a boolean indicating whether or not the state at the given
   // path is current.
   //
   // Returns `true` or `false`.
   // Throws `Error` if the path cannot be resolved.
-  State.prototype.isCurrent = function(path) {
+  State.prototype.isCurrent = function pState_isCurrent(path) {
     var state = this.resolve(path);
     return !!(state && state.__isCurrent__);
   };
@@ -747,7 +747,7 @@
   //
   // Returns the `State` object the path represents if it can be resolve and
   //   `null` otherwise.
-  State.prototype.resolve = function(path) {
+  State.prototype.resolve = function pState_resolve(path) {
     var head, next, i, n;
 
     if (!path) { return null; }
@@ -777,7 +777,7 @@
   };
 
   // Public: Returns a formatted string with the state's full path.
-  State.prototype.toString = function() { return 'State(' + this.path() + ')'; }
+  State.prototype.toString = function pState_toString() { return 'State(' + this.path() + ')'; }
 
   exports.State = State;
 }(typeof exports === 'undefined' ? this.statechart = {} : exports));

--- a/statechart.js
+++ b/statechart.js
@@ -424,362 +424,360 @@
     return s;
   };
 
-  State.prototype = {
-    // Public: Creates a substate with the given name and adds it as a substate to
-    // the receiver state. If a `State` object is given, then it simply adds the
-    // state as a substate. This allows you to split up the definition of your
-    // states instead of defining everything in one place.
-    //
-    // name - A string containing the name of the state or a `State` object.
-    // opts - An object of options to pass to the `State` constructor
-    //        (default: `null`).
-    // f    - A function to invoke in the context of the newly created state
-    //        (default: `null`).
-    //
-    // Examples
-    //
-    //   var s2 = new State('s2');
-    //   s2.state('s21');
-    //   s2.state('s22');
-    //
-    //   var sc = State.define(function() {
-    //     this.state('s', function() {
-    //       this.state('s1', function() {
-    //         this.state('s11');
-    //         this.state('s12');
-    //       });
-    //
-    //       this.state(s2);
-    //     });
-    //   });
-    //
-    // Returns the newly created state.
-    state: function(name) {
+  // Public: Creates a substate with the given name and adds it as a substate to
+  // the receiver state. If a `State` object is given, then it simply adds the
+  // state as a substate. This allows you to split up the definition of your
+  // states instead of defining everything in one place.
+  //
+  // name - A string containing the name of the state or a `State` object.
+  // opts - An object of options to pass to the `State` constructor
+  //        (default: `null`).
+  // f    - A function to invoke in the context of the newly created state
+  //        (default: `null`).
+  //
+  // Examples
+  //
+  //   var s2 = new State('s2');
+  //   s2.state('s21');
+  //   s2.state('s22');
+  //
+  //   var sc = State.define(function() {
+  //     this.state('s', function() {
+  //       this.state('s1', function() {
+  //         this.state('s11');
+  //         this.state('s12');
+  //       });
+  //
+  //       this.state(s2);
+  //     });
+  //   });
+  //
+  // Returns the newly created state.
+  State.prototype.state = function(name, options, f) {
       var s = name instanceof State ? name :
         State.apply(null, slice.call(arguments));
       this.addSubstate(s);
       return s;
-    },
-
-    // Public: Registers an enter handler to be called with the receiver state
-    // is entered. The `context` option passed to `goto` will be passed to the
-    // given function when invoked.
-    //
-    // Multiple enter handlers may be registered per state. They are invoked in
-    // the order in which they are defined.
-    //
-    // f - A function to call when the state is entered.
-    //
-    // Returns the receiver.
-    enter: function(f) { this.enters.push(f); return this; },
-
-    // Public: Registers an exit handler to be called with the receiver state
-    // is exited. The `context` option passed to `goto` will be passed to the
-    // given function when invoked.
-    //
-    // Multiple exit handlers may be registered per state. They are invoked in
-    // the order in which they are defined.
-    //
-    // f - A function to call when the state is exited.
-    //
-    // Returns the receiver.
-    exit: function(f) { this.exits.push(f); return this; },
-
-    // Public: Registers an event handler to be called when an event with a
-    // matching name is sent to the state via the `send` method.
-    //
-    // Only one event handler may be registered per event.
-    //
-    // name - The name of the event.
-    // f    - A function to call when the event occurs.
-    //
-    // Returns the receiver.
-    event: function(name, f) { this.events[name] = f; return this; },
-
-    // Public: Defines a condition state on the receiver state. Condition states
-    // are consulted when entering a clustered state without specified destination
-    // states. The given function should return a path to some substate of the
-    // state that the condition state is defined on.
-    //
-    // f - The condition function.
-    //
-    // Examples
-    //
-    //   var sc = State.define(function() {
-    //     this.state('a', function() {
-    //       this.C(function() {
-    //         if (shouldGoToB) { return './b'; }
-    //         if (shouldGoToC) { return './c'; }
-    //         if (shouldGoToD) { return './d'; }
-    //       });
-    //       this.state('b');
-    //       this.state('c');
-    //       this.state('d');
-    //     });
-    //   });
-    //
-    // Returns nothing.
-    C: function(f) {
-      if (this.concurrent) {
-        throw new Error('State#C: a concurrent state may not have a condition state: ' + this);
-      }
-
-      this.__condition__ = f;
-    },
-
-    // Public: Returns an array of paths to all current leaf states.
-    current: function() {
-      var states = _current.call(this), paths = [], i, n;
-
-      for (i = 0, n = states.length; i < n; i++) {
-        paths.push(states[i].path());
-      }
-
-      return paths;
-    },
-
-    // Public: The `State` iterator - invokes the given function once for each
-    // state in the statechart. The states are traversed in a preorder depth-first
-    // manner.
-    //
-    // f - A function object, it will be invoked once for each state.
-    //
-    // Returns the receiver.
-    each: function(f) {
-      var i, n;
-
-      f(this);
-
-      for (i = 0, n = this.substates.length; i < n; i++) {
-        this.substates[i].each(f);
-      }
-
-      return this;
-    },
-
-    // Public: Adds the given state as a substate of the receiver state.
-    //
-    // Returns the receiver.
-    addSubstate: function(state) {
-      var deep = this.deep;
-      this.substates.push(state);
-      state.each(function(s) {
-        s.__cache__ = {};
-        if (deep) { s.history = s.deep = true; }
-      });
-      state.superstate = this;
-      return this;
-    },
-
-    // Public: Returns the root state.
-    root: function() {
-      return this.__cache__.root = this.__cache__.root ||
-        (this.superstate ? this.superstate.root() : this);
-    },
-
-    // Public: Returns a string containing the full path from the root state to
-    // the receiver state. State paths are very similar to unix directory paths.
-    //
-    // Examples
-    //
-    //   var r = new State('root'),
-    //       a = new State('a'),
-    //       b = new State('b'),
-    //       c = new State('c');
-    //
-    //   r.addSubstate(a);
-    //   a.addSubstate(b);
-    //   b.addSubstate(c);
-    //
-    //   r.path(); // => "/"
-    //   a.path(); // => "/a"
-    //   b.path(); // => "/a/b"
-    //   c.path(); // => "/a/b/c"
-    path: function() {
-      var states = _path.call(this), names = [], i, len;
-
-      for (i = 1, len = states.length; i < len; i++) {
-        names.push(states[i].name);
-      }
-
-      return '/' + names.join('/');
-    },
-
-    // Public: Sets up a transition from the receiver state to the given
-    // destination states. Transitions are usually triggered during event
-    // handlers called by the `send` method. This method should be called on the
-    // root state to send the statechart into its initial set of current states.
-    //
-    // paths - Zero or more strings representing destination state paths (default:
-    //         `[]`).
-    // opts  - An object containing zero or more of the following keys:
-    //         context - An object to pass along to the `exit` and `enter` methods
-    //                   invoked during the actual transistion.
-    //         force   - Forces `enter` methods to be called during the transition
-    //                   on states that are already current.
-    //
-    // Examples
-    //
-    //   var sc = State.define(function() {
-    //     this.state('a', function() {
-    //       this.state('b', function() {
-    //         this.foo = function() { this.goto('../c'); };
-    //       });
-    //       this.state('c', function() {
-    //         this.bar = function() { this.goto('../b'); };
-    //       });
-    //     });
-    //   });
-    //
-    //   sc.goto();
-    //   sc.current();   // => ['/a/b']
-    //   sc.send('foo');
-    //   sc.current();   // => ['/a/c']
-    //   sc.send('bar');
-    //   sc.current();   // => ['/a/b']
-    //
-    // Returns the receiver.
-    // Throws an `Error` if called on a non-current non-root state.
-    // Throws an `Error` if multiple pivot states are found between the receiver
-    //   and destination states.
-    // Throws an `Error` if a destination path is not reachable from the receiver.
-    goto: function() {
-      var root   = this.root(),
-          paths  = flatten(slice.call(arguments)),
-          opts   = typeof paths[paths.length - 1] === 'object' ? paths.pop() : {},
-          states = [],
-          pivots = [],
-          state, pivot, i, n;
-
-      for (i = 0, n = paths.length; i < n; i++) {
-        if (!(state = this.resolve(paths[i]))) {
-          throw new Error('State#goto: could not resolve path ' + paths[i] + ' from ' + this);
-        }
-
-        states.push(state);
-      }
-
-      for (i = 0, n = states.length; i < n; i++) {
-        pivots.push(findPivot.call(this, states[i]));
-      }
-
-      if (notUnique(pivots)) {
-        throw new Error("State#goto: multiple pivot states found between state " + this + " and paths " + paths.join(', '));
-      }
-
-      pivot = pivots[0] || this;
-
-      trace.call(this, 'State: [GOTO]   : ' + this + ' -> [' + states.join(', ') + ']');
-
-      if (!this.__isCurrent__ && this.superstate) {
-        throw new Error('State#goto: state ' + this + ' is not current');
-      }
-
-      // if the pivot state is a concurrent state and is not also the starting
-      // state, then we're attempting to cross a concurrency boundary, which is
-      // not allowed
-      if (pivot.concurrent && pivot !== this) {
-        throw new Error('State#goto: one or more of the given paths are not reachable from state ' + this + ': ' +  paths.join(', '));
-      }
-
-      queueTransition.call(root, pivot, states, opts);
-
-      if (!this.__isSending__) { transition.call(root); }
-
-      return this;
-    },
-
-    // Public: Sends an event to the statechart. A statechart handles an event
-    // by giving each current leaf state an opportunity to handle it. Events
-    // bubble up superstate chains as long as handler methods do not return a
-    // truthy value. When a handler does return a truthy value (indicating that
-    // it has handled the event) the bubbling is canceled. A handler method is
-    // registered with the `event` method.
-    //
-    // event   - A string containing the event name.
-    // args... - Zero or more arguments that get passed on to the handler methods.
-    //
-    // Returns a boolean indicating whether or not the event was handled.
-    // Throws `Error` if the state is not current.
-    send: function() {
-      var args = slice.call(arguments), events = this.events, handled;
-
-      if (!this.__isCurrent__) {
-        throw new Error('State#send: attempted to send an event to a state that is not current: ' + this);
-      }
-
-      if (this === this.root()) {
-        trace.call(this, 'State: [EVENT]  : ' + args[0]);
-      }
-
-      handled = this.concurrent ? sendConcurrent.apply(this, arguments) :
-        sendClustered.apply(this, arguments);
-
-      if (!handled && typeof events[args[0]] === 'function') {
-        this.__isSending__ = true;
-        handled = !!events[args[0]].apply(this, args.slice(1));
-        this.__isSending__ = false;
-      }
-
-      if (!this.superstate) { transition.call(this); }
-
-      return handled;
-    },
-
-    // Public: Resets the statechart by exiting all current states.
-    reset: function() { exit.call(this, {}); },
-
-    // Public: Returns a boolean indicating whether or not the state at the given
-    // path is current.
-    //
-    // Returns `true` or `false`.
-    // Throws `Error` if the path cannot be resolved.
-    isCurrent: function(path) {
-      var state = this.resolve(path);
-      return !!(state && state.__isCurrent__);
-    },
-
-    // Public: Resolves a string path into an actual `State` object. Paths not
-    // starting with a '/' are resolved relative to the receiver state, paths that
-    // do start with a '/' are resolved relative to the root state.
-    //
-    // path      - A string containing the path to resolve or an array of path
-    //             segments.
-    //
-    // Returns the `State` object the path represents if it can be resolve and
-    //   `null` otherwise.
-    resolve: function(path) {
-      var head, next, i, n;
-
-      if (!path) { return null; }
-
-      path      = typeof path === 'string' ? path.split('/') : path;
-      head      = path.shift();
-
-      switch (head) {
-      case '':
-        next = this.root();
-        break;
-      case '.':
-        next = this;
-        break;
-      case '..':
-        next = this.superstate;
-        break;
-      default:
-        for (i = 0, n = this.substates.length; i < n; i++){
-          if (head === this.substates[i].name) { next = this.substates[i]; break; }
-        }
-      }
-
-      if (!next) { return null; }
-
-      return path.length === 0 ? next : next.resolve(path);
-    },
-
-    // Public: Returns a formatted string with the state's full path.
-    toString: function() { return 'State(' + this.path() + ')'; }
   };
+
+  // Public: Registers an enter handler to be called with the receiver state
+  // is entered. The `context` option passed to `goto` will be passed to the
+  // given function when invoked.
+  //
+  // Multiple enter handlers may be registered per state. They are invoked in
+  // the order in which they are defined.
+  //
+  // f - A function to call when the state is entered.
+  //
+  // Returns the receiver.
+  State.prototype.enter = function(f) { this.enters.push(f); return this; };
+
+  // Public: Registers an exit handler to be called with the receiver state
+  // is exited. The `context` option passed to `goto` will be passed to the
+  // given function when invoked.
+  //
+  // Multiple exit handlers may be registered per state. They are invoked in
+  // the order in which they are defined.
+  //
+  // f - A function to call when the state is exited.
+  //
+  // Returns the receiver.
+  State.prototype.exit = function(f) { this.exits.push(f); return this; };
+
+  // Public: Registers an event handler to be called when an event with a
+  // matching name is sent to the state via the `send` method.
+  //
+  // Only one event handler may be registered per event.
+  //
+  // name - The name of the event.
+  // f    - A function to call when the event occurs.
+  //
+  // Returns the receiver.
+  State.prototype.event = function(name, f) { this.events[name] = f; return this; };
+
+  // Public: Defines a condition state on the receiver state. Condition states
+  // are consulted when entering a clustered state without specified destination
+  // states. The given function should return a path to some substate of the
+  // state that the condition state is defined on.
+  //
+  // f - The condition function.
+  //
+  // Examples
+  //
+  //   var sc = State.define(function() {
+  //     this.state('a', function() {
+  //       this.C(function() {
+  //         if (shouldGoToB) { return './b'; }
+  //         if (shouldGoToC) { return './c'; }
+  //         if (shouldGoToD) { return './d'; }
+  //       });
+  //       this.state('b');
+  //       this.state('c');
+  //       this.state('d');
+  //     });
+  //   });
+  //
+  // Returns nothing.
+  State.prototype.C = function(f) {
+    if (this.concurrent) {
+      throw new Error('State#C: a concurrent state may not have a condition state: ' + this);
+    }
+
+    this.__condition__ = f;
+  };
+
+  // Public: Returns an array of paths to all current leaf states.
+  State.prototype.current = function() {
+    var states = _current.call(this), paths = [], i, n;
+
+    for (i = 0, n = states.length; i < n; i++) {
+      paths.push(states[i].path());
+    }
+
+    return paths;
+  };
+
+  // Public: The `State` iterator - invokes the given function once for each
+  // state in the statechart. The states are traversed in a preorder depth-first
+  // manner.
+  //
+  // f - A function object, it will be invoked once for each state.
+  //
+  // Returns the receiver.
+  State.prototype.each = function(f) {
+    var i, n;
+
+    f(this);
+
+    for (i = 0, n = this.substates.length; i < n; i++) {
+      this.substates[i].each(f);
+    }
+
+    return this;
+  };
+
+  // Public: Adds the given state as a substate of the receiver state.
+  //
+  // Returns the receiver.
+  State.prototype.addSubstate = function(state) {
+    var deep = this.deep;
+    this.substates.push(state);
+    state.each(function(s) {
+      s.__cache__ = {};
+      if (deep) { s.history = s.deep = true; }
+    });
+    state.superstate = this;
+    return this;
+  };
+
+  // Public: Returns the root state.
+  State.prototype.root = function() {
+    return this.__cache__.root = this.__cache__.root ||
+      (this.superstate ? this.superstate.root() : this);
+  };
+
+  // Public: Returns a string containing the full path from the root state to
+  // the receiver state. State paths are very similar to unix directory paths.
+  //
+  // Examples
+  //
+  //   var r = new State('root'),
+  //       a = new State('a'),
+  //       b = new State('b'),
+  //       c = new State('c');
+  //
+  //   r.addSubstate(a);
+  //   a.addSubstate(b);
+  //   b.addSubstate(c);
+  //
+  //   r.path(); // => "/"
+  //   a.path(); // => "/a"
+  //   b.path(); // => "/a/b"
+  //   c.path(); // => "/a/b/c"
+  State.prototype.path = function() {
+    var states = _path.call(this), names = [], i, len;
+
+    for (i = 1, len = states.length; i < len; i++) {
+      names.push(states[i].name);
+    }
+
+    return '/' + names.join('/');
+  };
+
+  // Public: Sets up a transition from the receiver state to the given
+  // destination states. Transitions are usually triggered during event
+  // handlers called by the `send` method. This method should be called on the
+  // root state to send the statechart into its initial set of current states.
+  //
+  // paths - Zero or more strings representing destination state paths (default:
+  //         `[]`).
+  // opts  - An object containing zero or more of the following keys:
+  //         context - An object to pass along to the `exit` and `enter` methods
+  //                   invoked during the actual transistion.
+  //         force   - Forces `enter` methods to be called during the transition
+  //                   on states that are already current.
+  //
+  // Examples
+  //
+  //   var sc = State.define(function() {
+  //     this.state('a', function() {
+  //       this.state('b', function() {
+  //         this.foo = function() { this.goto('../c'); };
+  //       });
+  //       this.state('c', function() {
+  //         this.bar = function() { this.goto('../b'); };
+  //       });
+  //     });
+  //   });
+  //
+  //   sc.goto();
+  //   sc.current();   // => ['/a/b']
+  //   sc.send('foo');
+  //   sc.current();   // => ['/a/c']
+  //   sc.send('bar');
+  //   sc.current();   // => ['/a/b']
+  //
+  // Returns the receiver.
+  // Throws an `Error` if called on a non-current non-root state.
+  // Throws an `Error` if multiple pivot states are found between the receiver
+  //   and destination states.
+  // Throws an `Error` if a destination path is not reachable from the receiver.
+  State.prototype.goto = function() {
+    var root   = this.root(),
+        paths  = flatten(slice.call(arguments)),
+        opts   = typeof paths[paths.length - 1] === 'object' ? paths.pop() : {},
+        states = [],
+        pivots = [],
+        state, pivot, i, n;
+
+    for (i = 0, n = paths.length; i < n; i++) {
+      if (!(state = this.resolve(paths[i]))) {
+        throw new Error('State#goto: could not resolve path ' + paths[i] + ' from ' + this);
+      }
+
+      states.push(state);
+    }
+
+    for (i = 0, n = states.length; i < n; i++) {
+      pivots.push(findPivot.call(this, states[i]));
+    }
+
+    if (notUnique(pivots)) {
+      throw new Error("State#goto: multiple pivot states found between state " + this + " and paths " + paths.join(', '));
+    }
+
+    pivot = pivots[0] || this;
+
+    trace.call(this, 'State: [GOTO]   : ' + this + ' -> [' + states.join(', ') + ']');
+
+    if (!this.__isCurrent__ && this.superstate) {
+      throw new Error('State#goto: state ' + this + ' is not current');
+    }
+
+    // if the pivot state is a concurrent state and is not also the starting
+    // state, then we're attempting to cross a concurrency boundary, which is
+    // not allowed
+    if (pivot.concurrent && pivot !== this) {
+      throw new Error('State#goto: one or more of the given paths are not reachable from state ' + this + ': ' +  paths.join(', '));
+    }
+
+    queueTransition.call(root, pivot, states, opts);
+
+    if (!this.__isSending__) { transition.call(root); }
+
+    return this;
+  };
+
+  // Public: Sends an event to the statechart. A statechart handles an event
+  // by giving each current leaf state an opportunity to handle it. Events
+  // bubble up superstate chains as long as handler methods do not return a
+  // truthy value. When a handler does return a truthy value (indicating that
+  // it has handled the event) the bubbling is canceled. A handler method is
+  // registered with the `event` method.
+  //
+  // event   - A string containing the event name.
+  // args... - Zero or more arguments that get passed on to the handler methods.
+  //
+  // Returns a boolean indicating whether or not the event was handled.
+  // Throws `Error` if the state is not current.
+  State.prototype.send = function() {
+    var args = slice.call(arguments), events = this.events, handled;
+
+    if (!this.__isCurrent__) {
+      throw new Error('State#send: attempted to send an event to a state that is not current: ' + this);
+    }
+
+    if (this === this.root()) {
+      trace.call(this, 'State: [EVENT]  : ' + args[0]);
+    }
+
+    handled = this.concurrent ? sendConcurrent.apply(this, arguments) :
+      sendClustered.apply(this, arguments);
+
+    if (!handled && typeof events[args[0]] === 'function') {
+      this.__isSending__ = true;
+      handled = !!events[args[0]].apply(this, args.slice(1));
+      this.__isSending__ = false;
+    }
+
+    if (!this.superstate) { transition.call(this); }
+
+    return handled;
+  };
+
+  // Public: Resets the statechart by exiting all current states.
+  State.prototype.reset = function() { exit.call(this, {}); };
+
+  // Public: Returns a boolean indicating whether or not the state at the given
+  // path is current.
+  //
+  // Returns `true` or `false`.
+  // Throws `Error` if the path cannot be resolved.
+  State.prototype.isCurrent = function(path) {
+    var state = this.resolve(path);
+    return !!(state && state.__isCurrent__);
+  };
+
+  // Public: Resolves a string path into an actual `State` object. Paths not
+  // starting with a '/' are resolved relative to the receiver state, paths that
+  // do start with a '/' are resolved relative to the root state.
+  //
+  // path      - A string containing the path to resolve or an array of path
+  //             segments.
+  //
+  // Returns the `State` object the path represents if it can be resolve and
+  //   `null` otherwise.
+  State.prototype.resolve = function(path) {
+    var head, next, i, n;
+
+    if (!path) { return null; }
+
+    path      = typeof path === 'string' ? path.split('/') : path;
+    head      = path.shift();
+
+    switch (head) {
+    case '':
+      next = this.root();
+      break;
+    case '.':
+      next = this;
+      break;
+    case '..':
+      next = this.superstate;
+      break;
+    default:
+      for (i = 0, n = this.substates.length; i < n; i++){
+        if (head === this.substates[i].name) { next = this.substates[i]; break; }
+      }
+    }
+
+    if (!next) { return null; }
+
+    return path.length === 0 ? next : next.resolve(path);
+  };
+
+  // Public: Returns a formatted string with the state's full path.
+  State.prototype.toString = function() { return 'State(' + this.path() + ')'; }
 
   exports.State = State;
 }(typeof exports === 'undefined' ? this.statechart = {} : exports));

--- a/statechart.js
+++ b/statechart.js
@@ -375,7 +375,6 @@
     }
 
     this.name          = name;
-    this.substateMap   = {};
     this.substates     = [];
     this.superstate    = null;
     this.enters        = [];
@@ -567,7 +566,6 @@
     // Returns the receiver.
     addSubstate: function(state) {
       var deep = this.history && this.deep;
-      this.substateMap[state.name] = state;
       this.substates.push(state);
       state.each(function(s) {
         s.__cache__ = {};
@@ -755,7 +753,7 @@
     // Returns the `State` object the path represents if it can be resolve and
     //   `null` otherwise.
     resolve: function(path) {
-      var head, next;
+      var head, next, i, n;
 
       if (!path) { return null; }
 
@@ -773,7 +771,9 @@
         next = this.superstate;
         break;
       default:
-        next = this.substateMap[head];
+        for (i = 0, n = this.substates.length; i < n; i++){
+          if (head === this.substates[i].name) { next = this.substates[i]; break; }
+        }
       }
 
       if (!next) { return null; }

--- a/statechart.js
+++ b/statechart.js
@@ -178,12 +178,8 @@
         }
         return enterClustered.call(this, states, opts);
       }
-      else if (this.history) {
-        next = this.__previous__ || this.substates[0];
-      }
-      else {
-        next = this.substates[0];
-      }
+      if (this.history) next = this.__previous__;
+      if (!next) next = this.substates[0];
     }
 
     if (cur && cur !== next) { exit.call(cur, opts); }
@@ -423,8 +419,7 @@
       }
     }
 
-    s = new State('__root__', opts);
-    if (f) { f.call(s); }
+    s = new State('__root__', opts, f);
     return s;
   };
 
@@ -565,7 +560,7 @@
     //
     // Returns the receiver.
     addSubstate: function(state) {
-      var deep = this.history && this.deep;
+      var deep = this.deep;
       this.substates.push(state);
       state.each(function(s) {
         s.__cache__ = {};

--- a/statechart.js
+++ b/statechart.js
@@ -27,7 +27,7 @@
 
   // Internal: Returns a boolean indicating whether there are multiple unique
   // values in the given array.
-  function multipleUniqs(array) {
+  function notUnique(array) {
     var x, i, n;
 
     if (!array || array.length === 0) { return false; }
@@ -162,7 +162,7 @@
       nexts.push(_path.call(states[i])[selflen]);
     }
 
-    if (multipleUniqs(nexts)) {
+    if (notUnique(nexts)) {
       throw new Error("State#enterClustered: attempted to enter multiple substates of " + this + ": " + nexts.join(', '));
     }
 
@@ -669,7 +669,7 @@
         pivots.push(findPivot.call(this, states[i]));
       }
 
-      if (multipleUniqs(pivots)) {
+      if (notUnique(pivots)) {
         throw new Error("State#goto: multiple pivot states found between state " + this + " and paths " + paths.join(', '));
       }
 

--- a/statechart.js
+++ b/statechart.js
@@ -684,7 +684,7 @@
   //   sc.send('bar');
   //   sc.current();   // => ['/a/b']
   //
-  // Returns the receiver.
+  // Returns boolean. `false` if transition failed.
   // Throws an `Error` if called on a non-current non-root state.
   // Throws an `Error` if multiple pivot states are found between the receiver
   //   and destination states.
@@ -717,7 +717,7 @@
 
     if (!canExit.call(pivot, states, opts)){
       trace.call(this, 'State: [GOTO]   : ' + this + ' can not exit]');
-      return this;
+      return false;
     }
 
     trace.call(this, 'State: [GOTO]   : ' + this + ' -> [' + states.join(', ') + ']');
@@ -737,7 +737,7 @@
 
     if (!this.__isSending__) { transition.call(root); }
 
-    return this;
+    return true;
   };
 
   // Public: Sends an event to the statechart. A statechart handles an event

--- a/statechart.js
+++ b/statechart.js
@@ -129,6 +129,20 @@
     }
   }
 
+  // Internal: Call all registered canExit functions.
+  //
+  // destStates - The destination states.
+  // context    - The destination context.
+  //
+  // Returns boolean. `false` if any canExit function returns false.
+  function callCanExitFunctions(destStates, context) {
+    var i, n;
+    for (i = 0, n = this.canExits.length; i < n; i++) {
+      if (this.canExits[i].call(this, destStates, context) === false) return false;
+    }
+    return true;
+  }
+
   // Internal: Enters a clustered state. Entering a clustered state involves
   // exiting the current substate (if one exists and is not a destination
   // state), invoking the `enter` callbacks on the receiver state, and
@@ -299,6 +313,25 @@
       exitConcurrent.call(this, opts) : exitClustered.call(this, opts);
   }
 
+  // Internal: Asks the receiver state if it can exit.
+  //
+  // destStates - The destination states.
+  // opts       - The options passed to `goto`.
+  //
+  // Returns boolean.
+  function canExit(destStates, opts) {
+    var i, n;
+    for (i = 0, n = this.substates.length; i < n; i++) {
+      if (this.substates[i].__isCurrent__) {
+        if (canExit.call(this.substates[i], destStates, opts) === false) {
+          return false
+        }
+      }
+    }
+
+    return callCanExitFunctions.call(this, destStates, opts.context);
+  }
+
   // Internal: Sends an event to a clustered state.
   //
   // Returns a boolean indicating whether or not the event was handled by the
@@ -371,6 +404,7 @@
     this.superstate      = null;
     this.enters          = [];
     this.exits           = [];
+    this.canExits        = [];
     this.events          = {};
     this.concurrent      = !!opts.concurrent;
     this.history         = !!(opts.H);
@@ -483,6 +517,19 @@
   //
   // Returns the receiver.
   State.prototype.exit = function pState_exit(f) { this.exits.push(f); return this; };
+
+  // Public: Registers a can exit function to be called before the receiver
+  // state is exited. The `context` option passed to `goto` will be passed to
+  // the given function when invoked.
+  //
+  // Multiple canExit functions may be registered per state. They are invoked
+  // in the order in which they are defined.
+  //
+  // f - A function to call before the state is exited. If the function
+  // returns false, no state transition occurs.
+  //
+  // Returns the receiver.
+  State.prototype.canExit = function pState_canExit(f) { this.canExits.push(f); return this; };
 
   // Public: Registers an event handler to be called when an event with a
   // matching name is sent to the state via the `send` method.
@@ -667,6 +714,11 @@
     }
 
     pivot = pivots[0] || this;
+
+    if (!canExit.call(pivot, states, opts)){
+      trace.call(this, 'State: [GOTO]   : ' + this + ' can not exit]');
+      return this;
+    }
 
     trace.call(this, 'State: [GOTO]   : ' + this + ' -> [' + states.join(', ') + ']');
 


### PR DESCRIPTION
1. I had a hard time wrapping my head around `multipleUniqs`. Renaming it to `notUnique` seems to make the function's intent clearer.
2. It looks like `origPath` and `origState` aren't being used (anymore).
3. Tracking the states in 2 properties seems like a bad idea. This is a potential fix (for a little cost).
4. The `|| this.substates[0]` seemed to repeat with the next conditional. `this.history && this.deep` seemed redundant, because `deep` stands for "deep history tracking" (maybe?).
5. There was a spot for initializing properties, so why not this one.

Also, I mentioned that the `_path` function sounds like it should return a string ("/root/state/baz"), and a name like `ancestors` would make more sense (but the name `ancestors` doesn't imply that it includes self).

### Additional changes

The next two changes are to make `State` inheritable. This way, in harbard, we could make our own `State` class that knows about routing.

6. Overriding `State.prototype` messed-up inheritance, so instead `prototype` is being extended.
7. Last few changes to allow inheriting from `State`.
8. It was getting tricky following jasmine output, so I named the functions. A little convenient if you are interested.