### PR TITLE
adding return clause in __route__ register under #_registerRoute, so …

### DIFF
--- a/lib/routable_state.js
+++ b/lib/routable_state.js
@@ -87,7 +87,7 @@
     var _this = this;
 
     this.__route__ = router.define(pattern, function(params) {
-      _this.root().goto(_this.path(), {force: true, context: params});
+      return _this.root().goto(_this.path(), {force: true, context: params});
     });
 
     if (opts.default) {


### PR DESCRIPTION
…that when statechart compares route.callback(params) === false, we have a boolean  rather than undefined to show for it, doont really know the scenario