### PR TITLE
Router to allow force pushState.

### DIFF
--- a/lib/routable_state.js
+++ b/lib/routable_state.js
@@ -92,7 +92,7 @@
 
     if (opts.default) {
       router.define('/', function(params) {
-        router.replace = true;
+        router.replace = false;
         return _this.root().goto(_this.path(), {force: true, context: params});
       });
     }

--- a/lib/routable_state.js
+++ b/lib/routable_state.js
@@ -92,7 +92,7 @@
 
     if (opts.default) {
       router.define('/', function(params) {
-        router.replace = false;
+        router.push = false;
         return _this.root().goto(_this.path(), {force: true, context: params});
       });
     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -390,7 +390,7 @@
 
     clearTimeout(this._timer);
     delete this._timer;
-    delete this.replace;
+    delete this.push;
 
     return this;
   };

--- a/lib/router.js
+++ b/lib/router.js
@@ -257,20 +257,23 @@
   //
   // params  - An object containing route params.
   // opts   - Zero ore more of the following options:
-  //          replace - A boolean indicating whether to replace or merge the given params with the existing
-  //                    params (default: `false`).
+  //          merge - A boolean indicating whether to replace or merge the given params with the existing
+  //                  params (default: `false`).
+  //          push  - A boolean indicating whether to use pushState or replaceState when updating history.
+  //                  (default: `false`)
   //
   // Returns the current route params.
   Router.prototype.params = function(params, opts) {
     if (!arguments.length) { return this.__params__; }
-    if (opts && opts.replace) {
+    if (opts && opts.merge === false) {
       this.__params__ = params || {};
     }
     else {
       util.assign(this.__params__, params);
     }
 
-    this._flush(opts);
+    this.push = this.push || (opts && opts.push);
+    this._flush();
 
     return this.__params__;
   };
@@ -359,10 +362,10 @@
   // Internal: Queues up a call to `Router#flush` via a `setTimeout`. `Router#flush` calls are
   // performed asynchronously so that multiple changes can be made the the params during a single
   // thread of execution before the brower's URL is updated.
-  Router.prototype._flush = function(opts) {
+  Router.prototype._flush = function() {
+    var _this = this;
     if (!this._timer) {
-      var flush = this.flush.bind(this, opts);
-      this._timer = setTimeout(function() { flush(); });
+      this._timer = setTimeout(function() { _this.flush(); });
     }
 
     return this;
@@ -377,17 +380,16 @@
   //          replace - A boolean indicating whether to replaceState or pushState (default: `false`).
   //
   // Returns the receiver.
-  Router.prototype.flush = function(opts) {
-    opts = opts || {};
+  Router.prototype.flush = function() {
     if (!this.__started__ || !this.__route__) { return this; }
 
     var curPath = this.__location__.pathname,
         path    = generatePath(this.__route__, this.__params__),
         search  = generateSearch(this.__route__, this.__params__),
         url     = buildUrl(path, search),
-        replace = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
+        push    = curPath !== path || this.push;
 
-    this.__history__[replace ? 'replaceState' : 'pushState']({}, null, url);
+    this.__history__[push ? 'pushState' : 'replaceState']({}, null, url);
 
     clearTimeout(this._timer);
     delete this._timer;

--- a/lib/router.js
+++ b/lib/router.js
@@ -286,7 +286,7 @@
     for (i = 0, n = this.__routes__.length; i < n; i++) {
       route = this.__routes__[i];
       if (route.regex.exec(path)) { return route; }
-    } 
+    }
 
     return null;
   };
@@ -362,9 +362,7 @@
   Router.prototype._flush = function(opts) {
     if (!this._timer) {
       var flush = this.flush.bind(this, opts);
-      this._timer = setTimeout(function() {
-        flush();
-      });
+      this._timer = setTimeout(function() { flush(); });
     }
 
     return this;
@@ -387,7 +385,7 @@
         path          = generatePath(this.__route__, this.__params__),
         search        = generateSearch(this.__route__, this.__params__),
         url           = buildUrl(path, search),
-        replace  = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
+        replace       = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
 
     this.__history__[replace ? 'replaceState' : 'pushState']({}, null, url);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -265,7 +265,10 @@
   // Returns the current route params.
   Router.prototype.params = function(params, opts) {
     if (!arguments.length) { return this.__params__; }
-    if (opts && opts.merge === false) {
+    if (opts && (opts.merge === false || opts === true)) {
+      if(typeof opts === 'boolean'){
+        console && console.warn('Passing params() a boolean to merge/replace params been deprecated.  Please pass an options object (ex. {merge: false})');
+      }
       this.__params__ = params || {};
     }
     else {

--- a/lib/router.js
+++ b/lib/router.js
@@ -375,6 +375,9 @@
   // params have changed, the `window.history.replaceState` method is used instead so that a history
   // entry is not created.
   //
+  // opts   - Zero ore more of the following options:
+  //          replace - A boolean indicating whether to replaceState or pushState (default: `false`).
+  //
   // Returns the receiver.
   Router.prototype.flush = function(opts) {
     opts = opts || {};

--- a/lib/router.js
+++ b/lib/router.js
@@ -387,7 +387,7 @@
         path    = generatePath(this.__route__, this.__params__),
         search  = generateSearch(this.__route__, this.__params__),
         url     = buildUrl(path, search),
-        push    = curPath !== path || this.push;
+        push    = this.push == null ? (curPath !== path) : this.push;
 
     this.__history__[push ? 'pushState' : 'replaceState']({}, null, url);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -256,23 +256,20 @@
   // update the browser's URL.
   //
   // params  - An object containing route params.
-  // opts    - One or more of the following options:
-  //           replace - A boolean indicating whether to replace or merge the given params with the existing
-  //                     params (default: `false`).
-  //           push    - A boolean indicating whether to pushState or not.
+  // replace - A boolean indicating whether to replace or merge the given params with the existing
+  //           params (default: `false`).
   //
   // Returns the current route params.
-  Router.prototype.params = function(params, opts) {
-    opts = opts || {};
+  Router.prototype.params = function(params, replace) {
     if (!arguments.length) { return this.__params__; }
-    if (opts.replace) {
+    if (replace) {
       this.__params__ = params || {};
     }
     else {
       util.assign(this.__params__, params);
     }
 
-    this._flush(opts);
+    this._flush(replace);
 
     return this.__params__;
   };
@@ -361,18 +358,12 @@
   // Internal: Queues up a call to `Router#flush` via a `setTimeout`. `Router#flush` calls are
   // performed asynchronously so that multiple changes can be made the the params during a single
   // thread of execution before the brower's URL is updated.
-  //
-  // opts    - One or more of the following options:
-  //           replace - A boolean indicating whether to replace or merge the given params with the existing
-  //                     params (default: `false`).
-  //           push    - A boolean indicating whether to pushState or not.
-  //
-  Router.prototype._flush = function(opts) {
+  Router.prototype._flush = function(replace) {
     var _this = this;
 
     if (!this._timer) {
-      this._timer = setTimeout(function(opts) {
-        _this.flush(opts);
+      this._timer = setTimeout(function() {
+        _this.flush(replace);
       });
     }
 
@@ -384,22 +375,17 @@
   // params have changed, the `window.history.replaceState` method is used instead so that a history
   // entry is not created.
   //
-  // opts    - One or more of the following options:
-  //           replace - A boolean indicating whether to replace or merge the given params with the existing
-  //                     params (default: `false`).
-  //           push    - A boolean indicating whether to pushState or not.
-  //
   // Returns the receiver.
-  Router.prototype.flush = function(opts) {
+  Router.prototype.flush = function(replace) {
     if (!this.__started__ || !this.__route__) { return this; }
 
-    var curPath = this.__location__.pathname,
-        path    = generatePath(this.__route__, this.__params__),
-        search  = generateSearch(this.__route__, this.__params__),
-        url     = buildUrl(path, search),
-        replace = this.replace || curPath === path;
+    var curPath       = this.__location__.pathname,
+        path          = generatePath(this.__route__, this.__params__),
+        search        = generateSearch(this.__route__, this.__params__),
+        url           = buildUrl(path, search),
+        replaceState  = typeof replace === 'undefined' ? curPath === path : replace;
 
-    this.__history__[replace && !(opts && opts.push) ? 'replaceState' : 'pushState']({}, null, url);
+    this.__history__[replaceState ? 'replaceState' : 'pushState']({}, null, url);
 
     clearTimeout(this._timer);
     delete this._timer;

--- a/lib/router.js
+++ b/lib/router.js
@@ -381,11 +381,11 @@
     opts = opts || {};
     if (!this.__started__ || !this.__route__) { return this; }
 
-    var curPath       = this.__location__.pathname,
-        path          = generatePath(this.__route__, this.__params__),
-        search        = generateSearch(this.__route__, this.__params__),
-        url           = buildUrl(path, search),
-        replace       = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
+    var curPath = this.__location__.pathname,
+        path    = generatePath(this.__route__, this.__params__),
+        search  = generateSearch(this.__route__, this.__params__),
+        url     = buildUrl(path, search),
+        replace = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
 
     this.__history__[replace ? 'replaceState' : 'pushState']({}, null, url);
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -256,20 +256,23 @@
   // update the browser's URL.
   //
   // params  - An object containing route params.
-  // replace - A boolean indicating whether to replace or merge the given params with the existing
-  //           params (default: `false`).
+  // opts    - One or more of the following options:
+  //           replace - A boolean indicating whether to replace or merge the given params with the existing
+  //                     params (default: `false`).
+  //           push    - A boolean indicating whether to pushState or not.
   //
   // Returns the current route params.
-  Router.prototype.params = function(params, replace) {
+  Router.prototype.params = function(params, opts) {
+    opts = opts || {};
     if (!arguments.length) { return this.__params__; }
-    if (replace) {
+    if (opts.replace) {
       this.__params__ = params || {};
     }
     else {
       util.assign(this.__params__, params);
     }
 
-    this._flush();
+    this._flush(opts);
 
     return this.__params__;
   };
@@ -358,11 +361,19 @@
   // Internal: Queues up a call to `Router#flush` via a `setTimeout`. `Router#flush` calls are
   // performed asynchronously so that multiple changes can be made the the params during a single
   // thread of execution before the brower's URL is updated.
-  Router.prototype._flush = function() {
+  //
+  // opts    - One or more of the following options:
+  //           replace - A boolean indicating whether to replace or merge the given params with the existing
+  //                     params (default: `false`).
+  //           push    - A boolean indicating whether to pushState or not.
+  //
+  Router.prototype._flush = function(opts) {
     var _this = this;
 
     if (!this._timer) {
-      this._timer = setTimeout(function() { _this.flush(); });
+      this._timer = setTimeout(function(opts) {
+        _this.flush(opts);
+      });
     }
 
     return this;
@@ -373,8 +384,13 @@
   // params have changed, the `window.history.replaceState` method is used instead so that a history
   // entry is not created.
   //
+  // opts    - One or more of the following options:
+  //           replace - A boolean indicating whether to replace or merge the given params with the existing
+  //                     params (default: `false`).
+  //           push    - A boolean indicating whether to pushState or not.
+  //
   // Returns the receiver.
-  Router.prototype.flush = function() {
+  Router.prototype.flush = function(opts) {
     if (!this.__started__ || !this.__route__) { return this; }
 
     var curPath = this.__location__.pathname,
@@ -383,7 +399,7 @@
         url     = buildUrl(path, search),
         replace = this.replace || curPath === path;
 
-    this.__history__[replace ? 'replaceState' : 'pushState']({}, null, url);
+    this.__history__[replace && !(opts && opts.push) ? 'replaceState' : 'pushState']({}, null, url);
 
     clearTimeout(this._timer);
     delete this._timer;

--- a/lib/router.js
+++ b/lib/router.js
@@ -376,9 +376,6 @@
   // params have changed, the `window.history.replaceState` method is used instead so that a history
   // entry is not created.
   //
-  // opts   - Zero ore more of the following options:
-  //          replace - A boolean indicating whether to replaceState or pushState (default: `false`).
-  //
   // Returns the receiver.
   Router.prototype.flush = function() {
     if (!this.__started__ || !this.__route__) { return this; }

--- a/lib/router.js
+++ b/lib/router.js
@@ -256,20 +256,21 @@
   // update the browser's URL.
   //
   // params  - An object containing route params.
-  // replace - A boolean indicating whether to replace or merge the given params with the existing
-  //           params (default: `false`).
+  // opts   - Zero ore more of the following options:
+  //          replace - A boolean indicating whether to replace or merge the given params with the existing
+  //                    params (default: `false`).
   //
   // Returns the current route params.
-  Router.prototype.params = function(params, replace) {
+  Router.prototype.params = function(params, opts) {
     if (!arguments.length) { return this.__params__; }
-    if (replace) {
+    if (opts && opts.replace) {
       this.__params__ = params || {};
     }
     else {
       util.assign(this.__params__, params);
     }
 
-    this._flush(replace);
+    this._flush(opts);
 
     return this.__params__;
   };
@@ -285,7 +286,7 @@
     for (i = 0, n = this.__routes__.length; i < n; i++) {
       route = this.__routes__[i];
       if (route.regex.exec(path)) { return route; }
-    }
+    } 
 
     return null;
   };
@@ -358,12 +359,11 @@
   // Internal: Queues up a call to `Router#flush` via a `setTimeout`. `Router#flush` calls are
   // performed asynchronously so that multiple changes can be made the the params during a single
   // thread of execution before the brower's URL is updated.
-  Router.prototype._flush = function(replace) {
-    var _this = this;
-
+  Router.prototype._flush = function(opts) {
     if (!this._timer) {
+      var flush = this.flush.bind(this, opts);
       this._timer = setTimeout(function() {
-        _this.flush(replace);
+        flush();
       });
     }
 
@@ -376,16 +376,17 @@
   // entry is not created.
   //
   // Returns the receiver.
-  Router.prototype.flush = function(replace) {
+  Router.prototype.flush = function(opts) {
+    opts = opts || {};
     if (!this.__started__ || !this.__route__) { return this; }
 
     var curPath       = this.__location__.pathname,
         path          = generatePath(this.__route__, this.__params__),
         search        = generateSearch(this.__route__, this.__params__),
         url           = buildUrl(path, search),
-        replaceState  = typeof replace === 'undefined' ? curPath === path : replace;
+        replace  = typeof opts.replace === 'undefined' ? curPath === path : opts.replace;
 
-    this.__history__[replaceState ? 'replaceState' : 'pushState']({}, null, url);
+    this.__history__[replace ? 'replaceState' : 'pushState']({}, null, url);
 
     clearTimeout(this._timer);
     delete this._timer;

--- a/spec/router_spec.js
+++ b/spec/router_spec.js
@@ -383,7 +383,6 @@ describe('Router', function() {
           setTimeout(function() {
             router.params({foo: 'a', bar: 'b'}, {replace: false});
           }, 102);
-          debugger // eslint-disable-line
           jasmine.clock().tick(103);
 
           expect(router.params()).toEqual({id:6, foo: 'a', bar: 'b'});

--- a/spec/router_spec.js
+++ b/spec/router_spec.js
@@ -310,7 +310,7 @@ describe('Router', function() {
         router.params({a: 'b', c: 'd'});
         expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-        router.params({x: 'y'}, true);
+        router.params({x: 'y'}, {replace: true});
         expect(router.params()).toEqual({x: 'y'});
       });
 
@@ -338,7 +338,7 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-          router.params({x: 'y', a: 'blah'}, false);
+          router.params({x: 'y', a: 'blah'}, {replace: false});
           expect(router.params()).toEqual({a: 'blah', c: 'd', x: 'y'});
         });
 
@@ -347,7 +347,7 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-          router.params({x: 'y', a: 'ok'}, true);
+          router.params({x: 'y', a: 'ok'}, {replace: true});
           expect(router.params()).toEqual({x: 'y', a: 'ok'});
         });
 
@@ -381,8 +381,9 @@ describe('Router', function() {
           expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6');
 
           setTimeout(function() {
-            router.params({foo: 'a', bar: 'b'}, false);
+            router.params({foo: 'a', bar: 'b'}, {replace: false});
           }, 102);
+          debugger // eslint-disable-line
           jasmine.clock().tick(103);
 
           expect(router.params()).toEqual({id:6, foo: 'a', bar: 'b'});

--- a/spec/router_spec.js
+++ b/spec/router_spec.js
@@ -310,7 +310,7 @@ describe('Router', function() {
         router.params({a: 'b', c: 'd'});
         expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-        router.params({x: 'y'}, true);
+        router.params({x: 'y'}, {replace: true});
         expect(router.params()).toEqual({x: 'y'});
       });
 
@@ -321,6 +321,21 @@ describe('Router', function() {
         router.params({a: undefined, b: '22', c: false, d: null, e: 0});
         expect(router.params()).toEqual({b: '22', e: 0});
       });
+
+      describe('with push option', function() {
+        it('invokes pushState when only the search params have changed', function() {
+          router.route(this.showRoute);
+          router.params({id: 5});
+          router.flush();
+          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/5');
+
+          router.params({foo: 'a', bar: 'b'}, {push: true});
+          router.flush({push: true});
+          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/5?foo=a&bar=b');
+          expect(this.window.history.replaceState).not.toHaveBeenCalled();
+        });
+      });
+
     });
 
     describe('#urlFor', function() {

--- a/spec/router_spec.js
+++ b/spec/router_spec.js
@@ -310,7 +310,7 @@ describe('Router', function() {
         router.params({a: 'b', c: 'd'});
         expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-        router.params({x: 'y'}, {replace: true});
+        router.params({x: 'y'}, {merge: false});
         expect(router.params()).toEqual({x: 'y'});
       });
 
@@ -338,7 +338,7 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-          router.params({x: 'y', a: 'blah'}, {replace: false});
+          router.params({x: 'y', a: 'blah'}, {merge: true});
           expect(router.params()).toEqual({a: 'blah', c: 'd', x: 'y'});
         });
 
@@ -347,7 +347,7 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-          router.params({x: 'y', a: 'ok'}, {replace: true});
+          router.params({x: 'y', a: 'ok'}, {merge: false});
           expect(router.params()).toEqual({x: 'y', a: 'ok'});
         });
 
@@ -381,7 +381,7 @@ describe('Router', function() {
           expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6');
 
           setTimeout(function() {
-            router.params({foo: 'a', bar: 'b'}, {replace: false});
+            router.params({foo: 'a', bar: 'b'}, {push: true});
           }, 102);
           jasmine.clock().tick(103);
 

--- a/spec/router_spec.js
+++ b/spec/router_spec.js
@@ -322,8 +322,7 @@ describe('Router', function() {
         expect(router.params()).toEqual({b: '22', e: 0});
       });
 
-
-      describe('with replaceState', function() {
+      describe('[deprecated] boolean merge argument', function() {
         beforeEach(function() {
           router._timer = undefined;
           jasmine.clock().install();
@@ -338,7 +337,7 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
-          router.params({x: 'y', a: 'blah'}, {merge: true});
+          router.params({x: 'y', a: 'blah'}, false);
           expect(router.params()).toEqual({a: 'blah', c: 'd', x: 'y'});
         });
 
@@ -347,8 +346,67 @@ describe('Router', function() {
           router.params({a: 'b', c: 'd'});
           expect(router.params()).toEqual({a: 'b', c: 'd'});
 
+          router.params({x: 'y', a: 'ok'}, true);
+          expect(router.params()).toEqual({x: 'y', a: 'ok'});
+        });
+      });
+
+      describe('with merge', function() {
+        beforeEach(function() {
+          router._timer = undefined;
+          jasmine.clock().install();
+        });
+
+        afterEach(function() {
+          jasmine.clock().uninstall();
+        });
+
+        it('set to true, merges with existing params', function() {
+          router.route(this.searchRoute);
+          router.params({a: 'b', c: 'd'});
+          expect(router.params()).toEqual({a: 'b', c: 'd'});
+
+          router.params({x: 'y', a: 'blah'}, {merge: true});
+          expect(router.params()).toEqual({a: 'blah', c: 'd', x: 'y'});
+        });
+
+        it('set to false, replaces with existing params', function() {
+          router.route(this.searchRoute);
+          router.params({a: 'b', c: 'd'});
+          expect(router.params()).toEqual({a: 'b', c: 'd'});
+
           router.params({x: 'y', a: 'ok'}, {merge: false});
           expect(router.params()).toEqual({x: 'y', a: 'ok'});
+        });
+      });
+
+      describe('with push', function() {
+        beforeEach(function() {
+          router._timer = undefined;
+          jasmine.clock().install();
+        });
+
+        afterEach(function() {
+          jasmine.clock().uninstall();
+        });
+
+        it('set to true, invokes pushState when only the search params have changed', function() {
+          router.route(this.showRoute);
+          setTimeout(function() {
+            router.params({id: 6});
+          }, 100);
+          jasmine.clock().tick(101);
+
+          expect(router.params()).toEqual({id: 6});
+          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6');
+
+          setTimeout(function() {
+            router.params({foo: 'a', bar: 'b'}, {push: true});
+          }, 102);
+          jasmine.clock().tick(103);
+
+          expect(router.params()).toEqual({id:6, foo: 'a', bar: 'b'});
+          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6?foo=a&bar=b');
         });
 
         it('unset, invokes replaceState when only params changed', function() {
@@ -368,25 +426,6 @@ describe('Router', function() {
 
           expect(router.params()).toEqual({id:5, foo: 'a', bar: 'b'});
           expect(this.window.history.replaceState).toHaveBeenCalledWith({}, null, '/foos/5?foo=a&bar=b');
-        });
-
-        it('set to false, invokes pushState when only the search params have changed', function() {
-          router.route(this.showRoute);
-          setTimeout(function() {
-            router.params({id: 6});
-          }, 100);
-          jasmine.clock().tick(101);
-
-          expect(router.params()).toEqual({id: 6});
-          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6');
-
-          setTimeout(function() {
-            router.params({foo: 'a', bar: 'b'}, {push: true});
-          }, 102);
-          jasmine.clock().tick(103);
-
-          expect(router.params()).toEqual({id:6, foo: 'a', bar: 'b'});
-          expect(this.window.history.pushState).toHaveBeenCalledWith({}, null, '/foos/6?foo=a&bar=b');
         });
       });
     });


### PR DESCRIPTION
Currently when only params change replaceState is called. This updates the the router to allow force pushState or replaceState.

```js
router.params({x: 'y'}, {push: true});  // Use pushState
router.params({x: 'y'}, {push: false}); // Use replaceState
router.params({x: 'y'});                // Use replaceState
```

Note: We will need to update Centro Direct code to provide the replace option.

As we are changing the API for the second parameter, to maintain the existing functionality, a `merge` option is introduced for replacing all the params...

```js
router.params({x: 'y'}, {merge: true});  // Add `x` to params
router.params({x: 'y'}, {merge: false}); // Replace all params with just `x`
router.params({x: 'y'});                 // Add `x` to current params
```

